### PR TITLE
Fix for 400 Bad Request with empty arrays

### DIFF
--- a/src/ApiAbstract.php
+++ b/src/ApiAbstract.php
@@ -145,7 +145,9 @@ class ApiAbstract extends Authenticate
             foreach ($this->files as $file) {
                 $request->attach(...$file);
             }
-            $this->response = $request->send($method, $path, [$this->bodyFormat => $this->data]);
+            $params = [];
+            if (!empty($this->data)) $params = [$this->bodyFormat => $this->data];
+            $this->response = $request->send($method, $path, $params);
         } catch (Exception $exception) {
             $this->setErrors($exception);
         }


### PR DESCRIPTION
- Don't send request parameters when request body is empty
- Fixes 400 Bad Request: "Your client has issued a malformed or illegal request."